### PR TITLE
638- Remove text next to the Rennes logo in the footer

### DIFF
--- a/lib/FooterArea.vue
+++ b/lib/FooterArea.vue
@@ -25,9 +25,6 @@ function goTo(linkToFollow: String) {
   >
     <div class="flex p-0 gap-6">
       <UiRennesLogo class="w-36 h-7"></UiRennesLogo>
-      <div class="font-normal text-xs">
-        Visualisez les données thématiques du territoire sur la maquette 3D
-      </div>
     </div>
     <div
       class="flex flex-wrap items-end gap-[7px] pt-2 font-dm-sans font-normal text-xs leading-4 text-neutral-500 underline hover:cursor-pointer"


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-638

### Description

 Remove text next to the Rennes logo in the footer

### Screenshots

![image](https://github.com/sigrennesmetropole/cooperation_jn_common_ui/assets/126822753/8a38d6d7-22e3-4762-bf5e-b579088cc66c)
